### PR TITLE
fix pomfile to use released version of zxing libraries

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,12 +24,12 @@
   		<dependency>
   			<groupId>com.google.zxing</groupId>
   			<artifactId>javase</artifactId>
-  			<version>3.1.1-SNAPSHOT</version>
+  			<version>3.2.0</version>
   		</dependency>
   		<dependency>
   			<groupId>com.google.zxing</groupId>
   			<artifactId>core</artifactId>
-  			<version>3.1.1-SNAPSHOT</version>
+  			<version>3.2.0</version>
   		</dependency>
 	</dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -115,17 +115,16 @@
 		</plugins>
 	</reporting>
 
-	<url>http://code.google.com/p/gravity-jio</url>
+	<url>https://github.com/punchware/JIO-Library</url>
 
 	<issueManagement>
-		<system>googlecode</system>
-		<url>http://code.google.com/p/gravity-jio/issues/list</url>
+		<system>github</system>
+		<url>https://github.com/punchware/JIO-Library/issues</url>
 	</issueManagement>
 
 	<scm>
-		<developerConnection>scm:svn:https://gravity-jio.googlecode.com/svn/trunk/</developerConnection>
-		<connection>scm:svn:http://gravity-jio.googlecode.com/svn/trunk/</connection>
-		<url>http://code.google.com/p/gravity-jio/source/browse/</url>
+		<connection>git@github.com:punchware/JIO-Library.git</connection>
+		<url>https://github.com/punchware/JIO-Library/</url>
 	</scm>
 
 	<organization>


### PR DESCRIPTION
this change helps to resolve a released version of zxing dependencies. Useful for those who perform a clean setup of the project.